### PR TITLE
feat[#9]: 계좌 등록 및 1원 송금 인증 화면 UI 설계

### DIFF
--- a/src/components/common/OtpInput.tsx
+++ b/src/components/common/OtpInput.tsx
@@ -1,0 +1,74 @@
+import React, { useRef } from 'react';
+import { TextInput } from 'react-native';
+import styled from 'styled-components/native';
+import { theme } from '../../styles/theme';
+
+interface OtpInputProps {
+  code: string;
+  onChangeText: (text: string) => void;
+  maxLength?: number;
+  autoFocus?: boolean;
+}
+
+const OtpInput = ({
+  code,
+  onChangeText,
+  maxLength = 4,
+  autoFocus = true,
+}: OtpInputProps) => {
+  const inputRef = useRef<TextInput>(null);
+
+  const handleCodeChange = (text: string) => {
+    const numericText = text.replace(/[^0-9]/g, ''); // 숫자만 허용
+    onChangeText(numericText);
+  };
+
+  return (
+    <OtpInputContainer>
+      {Array.from({ length: maxLength }).map((_, index) => (
+        <OtpBox key={index} isFocused={index === code.length}>
+          <OtpText>{code[index] || ''}</OtpText>
+        </OtpBox>
+      ))}
+      <HiddenTextInput
+        ref={inputRef}
+        value={code}
+        onChangeText={handleCodeChange}
+        maxLength={maxLength}
+        keyboardType="number-pad"
+        autoFocus={autoFocus}
+      />
+    </OtpInputContainer>
+  );
+};
+
+export default OtpInput;
+
+const OtpInputContainer = styled.View`
+  flex-direction: row;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 24px;
+`;
+
+const OtpBox = styled.View<{ isFocused: boolean }>`
+  width: 60px;
+  height: 50px;
+  border-bottom-width: 2px;
+  border-color: ${(props) =>
+    props.isFocused ? theme.colors.primary : theme.colors.gray300};
+  justify-content: center;
+  align-items: center;
+`;
+
+const OtpText = styled.Text`
+  font-size: ${theme.fonts.title}px;
+  font-family: ${theme.fonts.Medium};
+`;
+
+const HiddenTextInput = styled.TextInput`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+`;

--- a/src/components/common/SuccessIcon.tsx
+++ b/src/components/common/SuccessIcon.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components/native';
+import { Ionicons } from '@expo/vector-icons';
+import { theme } from '../../styles/theme';
+
+interface SuccessIconProps {
+  size?: number;
+  iconColor?: string;
+  backgroundColor?: string;
+  borderColor?: string;
+}
+
+const SuccessIcon = ({
+  size = 80,
+  iconColor = theme.colors.primary,
+  backgroundColor = theme.colors.white,
+  borderColor = theme.colors.primary,
+}: SuccessIconProps) => {
+  return (
+    <IconContainer
+      size={size}
+      backgroundColor={backgroundColor}
+      borderColor={borderColor}
+    >
+      <Ionicons name="checkmark" size={size * 0.5} color={iconColor} />
+    </IconContainer>
+  );
+};
+
+export default SuccessIcon;
+
+const IconContainer = styled.View<{
+  size: number;
+  backgroundColor: string;
+  borderColor: string;
+}>`
+  width: ${(props) => props.size}px;
+  height: ${(props) => props.size}px;
+  border-radius: ${(props) => props.size / 2}px;
+  background-color: ${(props) => props.backgroundColor};
+  border: 2px solid ${(props) => props.borderColor};
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 24px;
+`;

--- a/src/components/common/Timer.tsx
+++ b/src/components/common/Timer.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components/native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { theme } from '../../styles/theme';
+import { formatTime } from '../../utils/timeFormat';
+
+interface TimerProps {
+  timeLeft: number;
+  isTimeUp?: boolean;
+}
+
+const Timer = ({ timeLeft, isTimeUp = false }: TimerProps) => {
+  return (
+    <TimerContainer>
+      <MaterialCommunityIcons
+        name="clock-outline"
+        size={20}
+        color={isTimeUp ? theme.colors.error : theme.colors.gray600}
+      />
+      <TimerText isTimeUp={isTimeUp}>{formatTime(timeLeft)}</TimerText>
+    </TimerContainer>
+  );
+};
+
+export default Timer;
+
+const TimerContainer = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 40px;
+`;
+
+const TimerText = styled.Text<{ isTimeUp: boolean }>`
+  font-size: ${theme.fonts.body}px;
+  font-family: ${theme.fonts.Regular};
+  color: ${(props) =>
+    props.isTimeUp ? theme.colors.error : theme.colors.gray600};
+`;

--- a/src/navigation/AuthNavigator.tsx
+++ b/src/navigation/AuthNavigator.tsx
@@ -22,10 +22,10 @@ const AuthNavigator = () => {
       <Stack.Screen name="Login" component={LoginScreen} />
       <Stack.Screen name="EmailLogin" component={EmailLoginScreen} />
       <Stack.Screen name="EmailInput" component={EmailInputScreen} />
-      {/* <Stack.Screen
+      <Stack.Screen
         name="EmailVerification"
         component={EmailVerificationScreen}
-      /> */}
+      />
       <Stack.Screen name="Password" component={PasswordScreen} />
       <Stack.Screen name="Nickname" component={NicknameScreen} />
       <Stack.Screen name="ProfileImage" component={ProfileImageScreen} />

--- a/src/navigation/MainNavigator.tsx
+++ b/src/navigation/MainNavigator.tsx
@@ -9,6 +9,8 @@ import AnalysisScreen from '../screens/analysis/AnalysisScreen';
 import MyPageScreen from '../screens/mypage/MyPageScreen';
 import ProfileEditScreen from '../screens/mypage/ProfileEditScreen';
 import AccountRegistrationScreen from '../screens/mypage/AccountRegistrationScreen';
+import AccountVerificationScreen from '../screens/mypage/AccountVerificationScreen';
+import AccountRegistrationCompleteScreen from '../screens/mypage/AccountRegistrationCompleteScreen';
 import PointGifticonScreen from '../screens/mypage/PointGifticonScreen';
 import PointCashoutScreen from '../screens/mypage/PointCashoutScreen';
 import NicknameSettingScreen from '../screens/mypage/NicknameSettingScreen';
@@ -27,6 +29,14 @@ const ProfileStack = () => {
       <Stack.Screen
         name="AccountRegistration"
         component={AccountRegistrationScreen}
+      />
+      <Stack.Screen
+        name="AccountVerification"
+        component={AccountVerificationScreen}
+      />
+      <Stack.Screen
+        name="AccountRegistrationComplete"
+        component={AccountRegistrationCompleteScreen}
       />
       <Stack.Screen name="PointGifticon" component={PointGifticonScreen} />
       <Stack.Screen name="PointCashout" component={PointCashoutScreen} />

--- a/src/screens/auth/email-signup/EmailInputScreen.tsx
+++ b/src/screens/auth/email-signup/EmailInputScreen.tsx
@@ -24,8 +24,8 @@ const EmailInputScreen = ({ navigation }: any) => {
 
   const handleNext = () => {
     if (isEmailValid) {
-      // navigation.navigate('EmailVerification', { email });
-      navigation.navigate('Password');
+      navigation.navigate('EmailVerification', { email });
+      // navigation.navigate('Password');
     }
   };
 

--- a/src/screens/auth/email-signup/EmailVerificationScreen.tsx
+++ b/src/screens/auth/email-signup/EmailVerificationScreen.tsx
@@ -1,24 +1,23 @@
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components/native';
+import { Image } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { View, Text } from 'react-native';
-import { MaterialCommunityIcons } from '@expo/vector-icons';
+import styled from 'styled-components/native';
 
-import Header from '../../../components/common/Header';
-import CustomButton from '../../../components/common/CustomButton';
 import { theme } from '../../../styles/theme';
-import { formatTime } from '../../../utils/timeFormat';
+import CustomButton from '../../../components/common/CustomButton';
+import Header from '../../../components/common/Header';
+import OtpInput from '../../../components/common/OtpInput';
+import Timer from '../../../components/common/Timer';
 
 const EmailVerificationScreen = ({ navigation }: any) => {
   const [code, setCode] = useState('');
   const [timeLeft, setTimeLeft] = useState(180); // 3분 타이머
 
   const isButtonEnabled = code.length === 4;
-  const isTimeUp = timeLeft === 0;
 
   // 타이머 로직 (UI 표시용)
   useEffect(() => {
-    if (isTimeUp) return;
+    if (timeLeft === 0) return;
     const intervalId = setInterval(() => {
       setTimeLeft(timeLeft - 1);
     }, 1000);
@@ -33,21 +32,14 @@ const EmailVerificationScreen = ({ navigation }: any) => {
   };
 
   const handleCodeChange = (text: string) => {
-    const numericText = text.replace(/[^0-9]/g, ''); // 숫자만 허용
-    setCode(numericText);
-  };
-
-  const handleResendCode = () => {
-    // TODO: 인증번호 재발송 로직 구현
-    setTimeLeft(180);
-    setCode('');
+    setCode(text);
   };
 
   return (
     <Container>
       <Header
         onBackPress={() => navigation.goBack()}
-        rightComponent={<ProgressText>1/5</ProgressText>}
+        rightComponent={<ProgressText>2/5</ProgressText>}
       />
 
       <Content>
@@ -56,36 +48,18 @@ const EmailVerificationScreen = ({ navigation }: any) => {
           이메일 인증을 해주세요.
         </Title>
 
-        <TimerContainer>
-          <MaterialCommunityIcons
-            name="clock-outline"
-            size={20}
-            color={isTimeUp ? theme.colors.error : theme.colors.gray600}
-          />
-          <TimerText isTimeUp={isTimeUp}>{formatTime(timeLeft)}</TimerText>
-        </TimerContainer>
+        <Timer timeLeft={timeLeft} />
 
-        <OtpInputContainer>
-          {[0, 1, 2, 3].map((index) => (
-            <OtpBox key={index} isFocused={index === code.length}>
-              <OtpText>{code[index] || ''}</OtpText>
-            </OtpBox>
-          ))}
-          <HiddenTextInput
-            value={code}
-            onChangeText={handleCodeChange}
-            maxLength={4}
-            keyboardType="number-pad"
-            autoFocus={true}
-            caretHidden={true}
-          />
-        </OtpInputContainer>
+        <OtpInput
+          code={code}
+          onChangeText={handleCodeChange}
+          maxLength={4}
+          autoFocus={true}
+        />
 
-        <ResendButton onPress={handleResendCode}>
+        <ResendButton>
           <ResendText>인증번호 재발송</ResendText>
         </ResendButton>
-
-        {isTimeUp && <ErrorMessage>인증 시간이 만료되었습니다.</ErrorMessage>}
 
         <CharacterImage
           source={require('../../../assets/images/character_shoo.png')}
@@ -98,7 +72,7 @@ const EmailVerificationScreen = ({ navigation }: any) => {
         <CustomButton
           text="인증하기"
           onPress={handleVerify}
-          disabled={!isButtonEnabled || isTimeUp}
+          disabled={!isButtonEnabled}
         />
       </ButtonWrapper>
     </Container>
@@ -121,88 +95,34 @@ const ProgressText = styled.Text`
 const Content = styled.View`
   flex: 1;
   padding: 24px;
-  justify-content: center;
-  align-items: center;
 `;
 
 const Title = styled.Text`
-  font-size: 24px;
+  font-size: ${theme.fonts.title}px;
   font-family: ${theme.fonts.Bold};
   color: ${theme.colors.gray900};
-  text-align: center;
   line-height: 34px;
-  margin-bottom: 32px;
-`;
-
-const TimerContainer = styled.View`
-  flex-direction: row;
-  align-items: center;
-  margin-bottom: 32px;
-`;
-
-const TimerText = styled.Text<{ isTimeUp: boolean }>`
-  font-size: 16px;
-  font-family: ${theme.fonts.Regular};
-  color: ${(props) =>
-    props.isTimeUp ? theme.colors.error : theme.colors.gray600};
-  margin-left: 8px;
-`;
-
-const OtpInputContainer = styled.View`
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 24px;
-  position: relative;
-`;
-
-const OtpBox = styled.View<{ isFocused: boolean }>`
-  width: 60px;
-  height: 60px;
-  border-width: 2px;
-  border-color: ${(props) =>
-    props.isFocused ? theme.colors.primary : theme.colors.gray300};
-  border-radius: 8px;
-  justify-content: center;
-  align-items: center;
-  margin: 0 8px;
-  background-color: ${theme.colors.white};
-`;
-
-const OtpText = styled.Text`
-  font-size: 24px;
-  font-family: ${theme.fonts.Bold};
-  color: ${theme.colors.gray900};
-`;
-
-const HiddenTextInput = styled.TextInput`
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  opacity: 0;
+  margin-top: 16px;
+  margin-bottom: 16px;
 `;
 
 const ResendButton = styled.TouchableOpacity`
-  margin-bottom: 24px;
+  align-self: flex-start;
 `;
 
 const ResendText = styled.Text`
-  font-size: 14px;
-  font-family: ${theme.fonts.Regular};
-  color: ${theme.colors.primary};
+  font-size: ${theme.fonts.caption}px;
+  font-family: ${theme.fonts.Medium};
+  color: ${theme.colors.gray600};
+  text-decoration-line: underline;
 `;
 
-const ErrorMessage = styled.Text`
-  font-size: 14px;
-  font-family: ${theme.fonts.Regular};
-  color: ${theme.colors.error};
-  margin-bottom: 24px;
-`;
-
+// 오른쪽 아래, 아래보다는 조금 위
 const CharacterImage = styled.Image`
-  width: 120px;
-  height: 120px;
-  margin-bottom: 48px;
+  position: absolute;
+  bottom: -24px;
+  right: -240px;
+  height: 280px;
 `;
 
 const ButtonWrapper = styled.View`

--- a/src/screens/mypage/AccountRegistrationCompleteScreen.tsx
+++ b/src/screens/mypage/AccountRegistrationCompleteScreen.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import styled from 'styled-components/native';
+
+import { theme } from '../../styles/theme';
+import CustomButton from '../../components/common/CustomButton';
+import SuccessIcon from '../../components/common/SuccessIcon';
+
+const AccountRegistrationCompleteScreen = ({ navigation }: any) => {
+  const handleComplete = () => {
+    // TODO: 메인 화면 또는 마이페이지로 이동
+    navigation.navigate('MyPage');
+  };
+
+  return (
+    <Container>
+      <Content>
+        <SuccessIcon size={80} />
+
+        <Title>등록 성공</Title>
+
+        <Description>계좌 등록을 성공적으로 완료했어요</Description>
+      </Content>
+
+      <ButtonWrapper>
+        <CustomButton text="완료" onPress={handleComplete} />
+      </ButtonWrapper>
+    </Container>
+  );
+};
+
+export default AccountRegistrationCompleteScreen;
+
+const Container = styled(SafeAreaView)`
+  flex: 1;
+  background-color: ${theme.colors.white};
+`;
+
+const Content = styled.View`
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+`;
+
+const Title = styled.Text`
+  font-size: ${theme.fonts.title}px;
+  font-family: ${theme.fonts.Bold};
+  color: ${theme.colors.gray900};
+  text-align: center;
+  line-height: 34px;
+  margin-bottom: 12px;
+`;
+
+const Description = styled.Text`
+  font-size: ${theme.fonts.body}px;
+  font-family: ${theme.fonts.Regular};
+  color: ${theme.colors.gray600};
+  text-align: center;
+  line-height: 24px;
+`;
+
+const ButtonWrapper = styled.View`
+  padding: 24px;
+`;

--- a/src/screens/mypage/AccountRegistrationScreen.tsx
+++ b/src/screens/mypage/AccountRegistrationScreen.tsx
@@ -47,7 +47,7 @@ const AccountRegistrationScreen = ({
   const handleRequestAuth = () => {
     if (isAccountValid) {
       // 1원 인증 요청 로직
-      console.log('1원 인증 요청');
+      navigation.navigate('AccountVerification');
     }
   };
 

--- a/src/screens/mypage/AccountVerificationScreen.tsx
+++ b/src/screens/mypage/AccountVerificationScreen.tsx
@@ -1,0 +1,165 @@
+import React, { useState, useEffect } from 'react';
+import { Image } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import styled from 'styled-components/native';
+
+import { theme } from '../../styles/theme';
+import CustomButton from '../../components/common/CustomButton';
+import Header from '../../components/common/Header';
+import OtpInput from '../../components/common/OtpInput';
+import Timer from '../../components/common/Timer';
+
+const AccountVerificationScreen = ({ navigation }: any) => {
+  const [code, setCode] = useState('');
+  const [timeLeft, setTimeLeft] = useState(180); // 3분 타이머
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const isButtonEnabled = code.length === 4;
+  const isTimeUp = timeLeft === 0;
+
+  // 타이머 로직 (UI 표시용)
+  useEffect(() => {
+    if (timeLeft === 0) return;
+    const intervalId = setInterval(() => {
+      setTimeLeft(timeLeft - 1);
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, [timeLeft]);
+
+  const handleVerify = () => {
+    // TODO: 계좌 인증 로직 구현
+
+    // 임시로 성공 처리 (실제로는 API 응답에 따라 처리)
+    navigation.navigate('AccountRegistrationComplete');
+  };
+
+  const handleCodeChange = (text: string) => {
+    setCode(text);
+    setErrorMessage(''); // 입력 시 에러 상태 초기화
+  };
+
+  const handleResendCode = () => {
+    // TODO: 1원 입금 재발송 로직 구현
+    setTimeLeft(180);
+    setCode('');
+    setErrorMessage('');
+  };
+
+  return (
+    <Container>
+      <Header onBackPress={() => navigation.goBack()} />
+
+      <Content>
+        <Title>계좌 인증을 해주세요</Title>
+
+        <Description>
+          계좌 거래내역에서 입금한 1원의 입금자명을 확인 후{'\n'}
+          4자리 숫자를 입력해 주세요
+        </Description>
+
+        <Timer timeLeft={timeLeft} isTimeUp={isTimeUp} />
+
+        <OtpInput
+          code={code}
+          onChangeText={handleCodeChange}
+          maxLength={4}
+          autoFocus={true}
+        />
+
+        <ResendButton onPress={handleResendCode}>
+          <ResendText>1원 입금 재발송</ResendText>
+        </ResendButton>
+
+        <ErrorContainer>
+          {errorMessage ? <ErrorMessage>{errorMessage}</ErrorMessage> : null}
+          {isTimeUp && <ErrorMessage>인증 시간이 만료되었습니다.</ErrorMessage>}
+        </ErrorContainer>
+
+        <CharacterImage
+          source={require('../../assets/images/character_shoo.png')}
+          resizeMode="contain"
+        />
+      </Content>
+
+      {/* 하단 버튼 */}
+      <ButtonWrapper>
+        <CustomButton
+          text="인증하기"
+          onPress={handleVerify}
+          // TODO: 4자리 숫자 입력 후 인증하기 버튼 활성화, 타이머 종료 후 인증하기 버튼 비활성화
+          // disabled={!isButtonEnabled || isTimeUp}
+        />
+      </ButtonWrapper>
+    </Container>
+  );
+};
+
+export default AccountVerificationScreen;
+
+const Container = styled(SafeAreaView)`
+  flex: 1;
+  background-color: ${theme.colors.white};
+`;
+
+const ProgressText = styled.Text`
+  font-size: 14px;
+  font-family: ${theme.fonts.Regular};
+  color: ${theme.colors.gray600};
+`;
+
+const Content = styled.View`
+  flex: 1;
+  padding: 24px;
+`;
+
+const Title = styled.Text`
+  font-size: ${theme.fonts.title}px;
+  font-family: ${theme.fonts.Bold};
+  color: ${theme.colors.gray900};
+  line-height: 34px;
+  margin-top: 16px;
+  margin-bottom: 16px;
+`;
+
+const Description = styled.Text`
+  font-size: ${theme.fonts.body}px;
+  font-family: ${theme.fonts.Regular};
+  color: ${theme.colors.gray600};
+  line-height: 24px;
+  margin-bottom: 16px;
+`;
+
+const ResendButton = styled.TouchableOpacity`
+  align-self: flex-start;
+`;
+
+const ResendText = styled.Text`
+  font-size: ${theme.fonts.caption}px;
+  font-family: ${theme.fonts.Medium};
+  color: ${theme.colors.gray600};
+  text-decoration-line: underline;
+`;
+
+const ErrorContainer = styled.View`
+  height: 20px;
+  justify-content: center;
+`;
+
+const ErrorMessage = styled.Text`
+  font-size: 14px;
+  font-family: ${theme.fonts.Regular};
+  color: ${theme.colors.error};
+`;
+
+// 오른쪽 아래, 아래보다는 조금 위
+const CharacterImage = styled.Image`
+  position: absolute;
+  bottom: -24px;
+  right: -240px;
+  height: 280px;
+`;
+
+const ButtonWrapper = styled.View`
+  padding: 24px;
+`;


### PR DESCRIPTION

## 변경 사항
계좌 등록 후 1원 인증 완료 시 표시되는 성공 화면을 구현했습니다.

### 주요 기능
- **SuccessIcon 공통 컴포넌트** 추가 (체크마크 아이콘)
- **AccountRegistrationCompleteScreen** 구현
- **네비게이션 연결** (인증 → 완료 화면)

### 일관성 유지
- 기존 화면들과 동일한 구조 (Container/Content/ButtonWrapper)
- 테마 시스템 활용 (폰트, 색상)
- 공통 컴포넌트 재사용

### 화면 구성
- 제목: "등록 성공"
- 설명: "계좌 등록을 성공적으로 완료했어요"
- 버튼: "완료" (마이페이지로 이동)

### 변경된 파일
- `src/components/common/SuccessIcon.tsx` (신규)
- `src/screens/mypage/AccountRegistrationCompleteScreen.tsx` (신규)
- `src/navigation/MainNavigator.tsx` (수정)
- `src/screens/mypage/AccountVerificationScreen.tsx` (수정)